### PR TITLE
feat: Add command support in textarea with /newpane command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@
 3. Make messages that are out of context red
 4. Fork out from a message into a new conversation in another pane✅
 5. Make opening in new pane work for shortcuts (i.e. alt+command+SHORTCUT)✅
-6. Commands inside textarea (/newpane What is x?)
+6. Commands inside textarea (/newpane What is x?)✅
 7. Query GPT4, Claude, and serpapi at the same time and show them side by side (opt-in)


### PR DESCRIPTION
Implement the ability to use commands directly in the message textarea.
- Add support for /newpane command to create a new conversation in a new pane
- Update placeholder text to indicate command functionality
- Maintain existing message sending behavior for non-command messages
- Mark feature as completed in README.md

This feature allows users to quickly create a new pane with a specific query without having to use keyboard shortcuts or multiple steps, improving workflow efficiency for power users.